### PR TITLE
Redirect authenticated users from root to chat in middleware

### DIFF
--- a/apps/web/app/(main)/components/sidebar-message-quota.tsx
+++ b/apps/web/app/(main)/components/sidebar-message-quota.tsx
@@ -13,7 +13,12 @@ export default function SidebarMessageQuota() {
   const { data: quotas, isLoading } = useMessageQuotas(idUser);
 
   // Don't show for subscribed users or while loading
-  if (subscription?.status === "active" || isLoading || !quotas) {
+  if (
+    subscription?.status === "active" ||
+    subscription?.status === "trialing" ||
+    isLoading ||
+    !quotas
+  ) {
     return null;
   }
 

--- a/apps/web/app/(main)/components/sidebar.tsx
+++ b/apps/web/app/(main)/components/sidebar.tsx
@@ -80,22 +80,23 @@ export const Sidebar = () => {
 
             <Separator />
 
-            {subscription?.status !== "active" && (
-              <>
-                <SidebarMessageQuota />
-                <Button
-                  variant="ghost"
-                  className="w-full px-6 py-5 flex justify-start rounded-none dark:text-violet-300 text-violet-500"
-                  asChild={true}
-                >
-                  <Link href="/subscribe">
-                    <Verify color="currentColor" className="size-5" />
-                    Subscribe to Armony
-                  </Link>
-                </Button>
-                <Separator />
-              </>
-            )}
+            {subscription?.status !== "active" &&
+              subscription?.status !== "trialing" && (
+                <>
+                  <SidebarMessageQuota />
+                  <Button
+                    variant="ghost"
+                    className="w-full px-6 py-5 flex justify-start rounded-none dark:text-violet-300 text-violet-500"
+                    asChild={true}
+                  >
+                    <Link href="/subscribe">
+                      <Verify color="currentColor" className="size-5" />
+                      Subscribe to Armony
+                    </Link>
+                  </Button>
+                  <Separator />
+                </>
+              )}
             {/* <Button
               variant="ghost"
               className="w-full px-6 py-5 flex justify-start rounded-none"

--- a/apps/web/app/api/chat/util/ai-calls.util.ts
+++ b/apps/web/app/api/chat/util/ai-calls.util.ts
@@ -35,7 +35,7 @@ export const checkUserSubscriptionQuotas = async ({
 }: { idUser: string }) => {
   const { status } = await getSubscriptionByUser(idUser);
 
-  if (status !== "active") {
+  if (status !== "active" && status !== "trialing") {
     // if not subscribed, check if user has reached the limit of 10 calls per 3 days
     const numberOfCalls = await getLast3daysAiCalls({ idUser });
 

--- a/apps/web/hooks/queries/client/use-ai-calls.query.ts
+++ b/apps/web/hooks/queries/client/use-ai-calls.query.ts
@@ -32,7 +32,10 @@ export const useMessageQuotas = (idUser: string | undefined | null) => {
 
       // Free users have limit of 10 messages per 3 days
       const messagesUsed = count ?? 0;
-      const messagesLimit = subscription?.status === "active" ? 200 : 10;
+      const messagesLimit =
+        subscription?.status === "active" || subscription?.status === "trialing"
+          ? 200
+          : 10;
       const percentageUsed = Math.min(
         100,
         (messagesUsed / messagesLimit) * 100,

--- a/packages/supabase/src/client/middleware.ts
+++ b/packages/supabase/src/client/middleware.ts
@@ -97,6 +97,11 @@ export async function updateSession(
 
   // Handle user-specific redirects first if authenticated
   if (user) {
+    // Redirect authenticated users from root to chat
+    if (pathname === "/") {
+      return createRedirectResponse(request, "/chat");
+    }
+
     // Redirect logged-in users from signin page to chat
     if (pathname === "/signin") {
       return createRedirectResponse(request, "/chat");

--- a/packages/supabase/src/client/middleware.ts
+++ b/packages/supabase/src/client/middleware.ts
@@ -40,12 +40,9 @@ const REDIRECT_ROUTES = [
   },
 ];
 
-export async function updateSession(
-  request: NextRequest,
-): Promise<NextResponse> {
+const createSupabaseClient = (request: NextRequest) => {
   let supabaseResponse = NextResponse.next({ request });
 
-  // Initialize Supabase client
   const supabase = createServerClient<Database>(
     // biome-ignore lint/style/noNonNullAssertion: <To simplify monorepo setup>
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -73,6 +70,45 @@ export async function updateSession(
     },
   );
 
+  return { supabase, supabaseResponse };
+};
+
+const handleAuthenticatedUserRedirects = (
+  request: NextRequest,
+  pathname: string,
+  userEmail: string | null | undefined,
+): NextResponse | null => {
+  // Redirect authenticated users from root to chat
+  if (pathname === "/") {
+    return createRedirectResponse(request, "/chat");
+  }
+
+  // Redirect logged-in users from signin page to chat
+  if (pathname === "/signin") {
+    return createRedirectResponse(request, "/chat");
+  }
+
+  // Redirect authenticated users from auth paths to home
+  if (pathname.startsWith("/auth")) {
+    return createRedirectResponse(request, "/");
+  }
+
+  // Check admin access
+  if (pathname.startsWith("/admin")) {
+    const isAdminUser = isAdmin(userEmail);
+    if (!isAdminUser) {
+      return createRedirectResponse(request, "/");
+    }
+  }
+
+  return null;
+};
+
+export async function updateSession(
+  request: NextRequest,
+): Promise<NextResponse> {
+  const { supabase } = createSupabaseClient(request);
+
   if (!supabase) {
     throw new Error("Supabase client not initialized");
   }
@@ -97,27 +133,13 @@ export async function updateSession(
 
   // Handle user-specific redirects first if authenticated
   if (user) {
-    // Redirect authenticated users from root to chat
-    if (pathname === "/") {
-      return createRedirectResponse(request, "/chat");
-    }
-
-    // Redirect logged-in users from signin page to chat
-    if (pathname === "/signin") {
-      return createRedirectResponse(request, "/chat");
-    }
-
-    // Redirect authenticated users from auth paths to home
-    if (pathname.startsWith("/auth")) {
-      return createRedirectResponse(request, "/");
-    }
-
-    // Check admin access
-    if (pathname.startsWith("/admin")) {
-      const isAdminUser = isAdmin(user.email);
-      if (!isAdminUser) {
-        return createRedirectResponse(request, "/");
-      }
+    const userRedirect = handleAuthenticatedUserRedirects(
+      request,
+      pathname,
+      user.email,
+    );
+    if (userRedirect) {
+      return userRedirect;
     }
   }
 


### PR DESCRIPTION
This pull request introduces a small but impactful update to the `updateSession` function in `packages/supabase/src/client/middleware.ts`. It adds a new redirect rule for authenticated users.

* [`packages/supabase/src/client/middleware.ts`](diffhunk://#diff-df114a50e7bdb522e1a9f19fdc6f19ee5f9b61c159f87dcc9442fc14633dcb38R100-R104): Authenticated users are now redirected from the root path (`/`) to the `/chat` page.